### PR TITLE
Allow switch between multiprocessing and threading

### DIFF
--- a/clkhash/benchmark.py
+++ b/clkhash/benchmark.py
@@ -9,8 +9,8 @@ from clkhash.clk import generate_clk_from_csv
 from clkhash.randomnames import NameList
 
 
-def compute_hash_speed(num, quiet=False):
-    # type: (int, bool) -> float
+def compute_hash_speed(num, quiet=False, use_multiprocessing=True):
+    # type: (int, bool, bool) -> float
     """ Hash time.
     """
     namelist = NameList(num)
@@ -28,7 +28,7 @@ def compute_hash_speed(num, quiet=False):
 
     with open(tmpfile_name, 'rt') as f:
         start = timer()
-        generate_clk_from_csv(f, 'secret', schema, progress_bar=not quiet)
+        generate_clk_from_csv(f, 'secret', schema, progress_bar=not quiet, use_multiprocessing=use_multiprocessing)
         end = timer()
 
     os.close(os_fd)

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -141,8 +141,9 @@ def cli(verbose):
 @click.option('--no-header', default=False, is_flag=True, help="Don't skip the first row")
 @click.option('--check-header', default=True, type=bool, help="If true, check the header against the schema")
 @click.option('--validate', default=True, type=bool, help="If true, validate the entries against the schema")
+@click.option('--multiprocessing', default=True, type=bool, help="If true, use multiprocessing to generate the keys from the secret")
 @verbose_option
-def hash(pii_csv, secret, schema, clk_json, no_header, check_header, validate, verbose):
+def hash(pii_csv, secret, schema, clk_json, no_header, check_header, validate, multiprocessing, verbose):
     """Process data to create CLKs
 
     Given a file containing CSV data as PII_CSV, and a JSON
@@ -173,7 +174,8 @@ def hash(pii_csv, secret, schema, clk_json, no_header, check_header, validate, v
             pii_csv, secret, schema_object,
             validate=validate,
             header=header,
-            progress_bar=verbose)
+            progress_bar=verbose,
+            use_multiprocessing=multiprocessing)
     except (validate_data.EntryError, validate_data.FormatError) as e:
         msg, = e.args
         log(msg)
@@ -404,8 +406,9 @@ def delete_project(project, apikey, server, retry_multiplier, retry_max_exp, ret
 
 
 @cli.command('benchmark', short_help='carry out a local benchmark')
-def benchmark():
-    bench.compute_hash_speed(10000)
+@click.option('--multiprocessing', default=True, type=bool, help="If true, use multiprocessing to generate the keys from the secret")
+def benchmark(multiprocessing):
+    bench.compute_hash_speed(10000, use_multiprocessing=multiprocessing)
 
 
 @cli.command('describe', short_help='show distribution of clk popcounts')

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -154,7 +154,7 @@ def generate_clks(pii_data,  # type: Sequence[Sequence[str]]
     futures = []
 
     # Compute Bloom filter from the chunks and then serialise it
-    with concurrent.futures.ProcessPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor() as executor:
         for chunk in chunks(pii_data, chunk_size):
             future = executor.submit(
                 hash_and_serialize_chunk,

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -53,7 +53,8 @@ def generate_clk_from_csv(input_f,  # type: TextIO
                           schema,  # type: Schema
                           validate=True,  # type: bool
                           header=True,  # type: Union[bool, AnyStr]
-                          progress_bar=True  # type: bool
+                          progress_bar=True,  # type: bool
+                          use_multiprocessing=True, # type: bool
                           ):
     # type: (...) -> List[str]
     """ Generate Bloom filters from CSV file, then serialise them.
@@ -75,6 +76,11 @@ def generate_clk_from_csv(input_f,  # type: TextIO
             header but it should not be checked against the schema.
         :param bool progress_bar: Set to `False` to disable the progress
             bar.
+        :param bool use_multiprocessing: Set to `False` to use threading to
+            generate keys for each identifier from the secret.  By default
+            multiprocessing is used to generate the keys.  Set this flag to
+            `False` if executing on a system that is not capable of spawning
+            subprocesses such as AWS Lambda functions.
         :return: A list of serialized Bloom filters and a list of
             corresponding popcounts.
     """
@@ -114,12 +120,16 @@ def generate_clk_from_csv(input_f,  # type: TextIO
                                     schema,
                                     secret,
                                     validate=validate,
-                                    callback=callback)
+                                    callback=callback,
+                                    use_multiprocessing=use_multiprocessing
+                                    )
     else:
         results = generate_clks(pii_data,
                                 schema,
                                 secret,
-                                validate=validate)
+                                validate=validate,
+                                use_multiprocessing=use_multiprocessing
+                                )
 
     log.info("Hashing took {:.2f} seconds".format(time.time() - start_time))
     return results
@@ -129,7 +139,8 @@ def generate_clks(pii_data,  # type: Sequence[Sequence[str]]
                   schema,  # type: Schema
                   secret,  # type: AnyStr
                   validate=True,  # type: bool
-                  callback=None  # type: Optional[Callable[[int, Sequence[int]], None]]
+                  callback=None,  # type: Optional[Callable[[int, Sequence[int]], None]]
+                  use_multiprocessing=True # type: bool
                   ):
     # type: (...) -> List[str]
 
@@ -154,7 +165,13 @@ def generate_clks(pii_data,  # type: Sequence[Sequence[str]]
     futures = []
 
     # Compute Bloom filter from the chunks and then serialise it
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+
+    if use_multiprocessing:
+        pool_executor = concurrent.futures.ProcessPoolExecutor
+    else:
+        pool_executor = concurrent.futures.ThreadPoolExecutor
+
+    with pool_executor() as executor:
         for chunk in chunks(pii_data, chunk_size):
             future = executor.submit(
                 hash_and_serialize_chunk,

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -187,12 +187,7 @@ A corresponding hashing schema can be generated as well::
             "weight": 0
           }
         },
-        {
-          "identifier": "NAME freetext",
-          "format": {
-            "type": "string",
-            "encoding": "utf-8",
-            "case": "mixed",
+        {s
             "minLength": 3
           },
           "hashing": {
@@ -238,8 +233,6 @@ can generate 10000 clks from a simple schema (data as generated :ref:`above <dat
     generating CLKs: 100%                 10.0K/10.0K [00:01<00:00, 7.72Kclk/s, mean=521, std=34.7]
      10000 hashes in 1.350489 seconds. 7.40 KH/s
 
-
-
 As a rule of thumb a single modern core will hash around 1M entities in about 20 minutes.
 
 .. note::
@@ -249,6 +242,16 @@ As a rule of thumb a single modern core will hash around 1M entities in about 20
 
 The output shows a running mean and std deviation of the generated clks' popcounts. This can be used
 as a basic sanity check - ensure the CLK's popcount is not around 0 or 1024.
+
+By default the benchmark uses multiprocessing to generate the clks, the performance difference by switching
+to multi-threading mode can also be determined by passing the command line option ``--multiprocessing 0``.
+
+    python -m clkhash.cli benchmark --multiprocessing 0
+    generating CLKs: 100%                 10.0K/10.0K [00:05<00:00, 1.90Kclk/s, mean=406, std=20.4]
+     10000 hashes in 5.285763 seconds. 1.89 KH/s
+
+The performance reduction in using multithreading mode is significant however it does allo clks to be 
+generated on hardware that does not allow multiprocessing such as AWS Lambda. 
 
 Interaction with Entity Service
 -------------------------------


### PR DESCRIPTION
AWS Lambda does not support multiprocessing and thus generate_clks fails.  I've added a flag to allow use of ThreadPoolExecutors as opposed to ProcessPoolExecutors to allow calls on Lambda.  There is a known processing time increase but this is considered acceptable given the alternative is prohibiting use on Lambda.